### PR TITLE
Initial fix for scoring issues and repeated hints

### DIFF
--- a/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardDivisionTable.jsx
+++ b/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardDivisionTable.jsx
@@ -11,7 +11,7 @@ import {
 } from 'semantic-ui-react';
 
 import { renderScore } from '../../../imports/PuzzleProgress';
-import { getHintsTaken } from '../../../../../lib/imports/puzzle-helpers';
+import { getHintsTaken, getFinalScore } from '../../../../../lib/imports/puzzle-helpers';
 
 const UNFINISHED_OFFSET = 26000;
 
@@ -20,7 +20,7 @@ class AdminLeaderboardDivisionTable extends Component {
     const { division, teams } = this.props;
 
     const sortedTeams = sortBy(teams, (team) => {
-      return team.finalScore + (team.finished ? 0 : UNFINISHED_OFFSET);
+      return getFinalScore(team) + (team.finished ? 0 : UNFINISHED_OFFSET);
     });
 
     return (
@@ -55,14 +55,15 @@ class AdminLeaderboardDivisionTable extends Component {
   }
 
   _renderTeamRow(team, i) {
-    const { _id: teamId, name, members, memberIds, puzzles, finalScore, finished } = team;
+    const { _id: teamId, name, members, memberIds, puzzles, finished } = team;
+    const finalScore = getFinalScore(team);
 
     return (
       <Table.Row key={teamId}>
         <Table.Cell>{i+1} | {name}</Table.Cell>
         <Table.Cell>{members.length} / {memberIds.length}</Table.Cell>
         <Table.Cell positive={finished} warning={!finished}>
-          <code>{renderScore(team.finalScore).time} ({team.finalScore} sec)</code> {!finished ? <Icon name="spinner" color="blue" loading /> : null}
+          <code>{renderScore(finalScore).time} ({finalScore} sec)</code> {!finished ? <Icon name="spinner" color="blue" loading /> : null}
         </Table.Cell>
         {puzzles.map((puzzle) => this._renderPuzzle(puzzle))}
       </Table.Row>

--- a/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardDivisionTable.jsx
+++ b/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardDivisionTable.jsx
@@ -11,6 +11,7 @@ import {
 } from 'semantic-ui-react';
 
 import { renderScore } from '../../../imports/PuzzleProgress';
+import { getHintsTaken } from '../../../../../lib/imports/puzzle-helpers';
 
 const UNFINISHED_OFFSET = 26000;
 
@@ -69,7 +70,8 @@ class AdminLeaderboardDivisionTable extends Component {
   }
 
   _renderPuzzle(puzzle) {
-    const { score, start, end, hintsTaken } = puzzle;
+    const { score, start, end } = puzzle;
+    let hintsTaken = getHintsTaken(puzzle);
     const started = Boolean(start);
     const finished = Boolean(end);
     const inProgress = started && !finished;

--- a/client/components/game/imports/GameStats.jsx
+++ b/client/components/game/imports/GameStats.jsx
@@ -3,6 +3,7 @@ import React, { Component, PropTypes } from 'react';
 import { Segment, Message, Header, Statistic, Progress } from 'semantic-ui-react';
 
 import { renderScore } from '../../imports/PuzzleProgress';
+import { getFinalScore } from '../../../../lib/imports/puzzle-helpers';
 
 const { eventYear } = Meteor.settings.public;
 
@@ -32,7 +33,7 @@ class GameStats extends Component {
   render() {
     const { team } = this.props;
     const { puzzlesSolved, finished } = this.state;
-    const { time, minutes } = renderScore(team.finalScore);
+    const { time, minutes } = renderScore(getFinalScore(team));
     return (
       <Message info={!finished} positive={finished}>
         {puzzlesSolved > 0 ? null : <Header as="h4" content="Starting Puzzle"/>}

--- a/client/components/game/imports/PuzzleHints.jsx
+++ b/client/components/game/imports/PuzzleHints.jsx
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import React, { PropTypes } from 'react';
 import { Segment, Grid, Header, Button, Image, Message, Confirm } from 'semantic-ui-react';
+import { getHintsTaken } from '../../../../lib/imports/puzzle-helpers';
 
 const HINT_COST = [5, 10, 15];
 
@@ -22,7 +23,7 @@ export default class PuzzleHints extends React.Component {
     if (!puzzle.hints || puzzle.hints.length === 0) return <br/>;
 
     const { showConfirm, hintToTake } = this.state;
-    const currentHintCost = HINT_COST[puzzle.hintsTaken];
+    const currentHintCost = HINT_COST[getHintsTaken(puzzle)];
 
     return (
       <Grid style={ this.gridStyle }>

--- a/client/components/imports/CompletePuzzle.jsx
+++ b/client/components/imports/CompletePuzzle.jsx
@@ -3,6 +3,7 @@ import { Segment, Header, Message, Statistic } from 'semantic-ui-react';
 import moment from 'moment';
 
 import PuzzleProgress, { renderScore } from './PuzzleProgress';
+import { getHintsTaken } from '../../../lib/imports/puzzle-helpers';
 
 export default class CompletePuzzle extends React.Component {
   render() {
@@ -31,11 +32,12 @@ export default class CompletePuzzle extends React.Component {
   _answer() {
     const { puzzle } = this.props;
     const { time, minutes } = renderScore(puzzle.score);
+    const hintsTaken = getHintsTaken(puzzle.hints);
     if (this.props.showAnswer) {
       return (
         <pre>
           Answer: { puzzle.answer }<br/>
-          Hints : { puzzle.hintsTaken }<br/>
+          Hints : { hintsTaken }<br/>
           Score : { time }<br/>
                   ({ minutes } minutes)
         </pre>

--- a/client/components/volunteer/GameProgress.jsx
+++ b/client/components/volunteer/GameProgress.jsx
@@ -5,6 +5,7 @@ import { sortBy, groupBy, map, clone, each } from 'lodash';
 import { Container, Grid, Icon, Header, Progress } from 'semantic-ui-react';
 import moment from 'moment';
 import { renderDuration } from '../imports/PuzzleProgress';
+import { getFinalScore } from '../../../lib/imports/puzzle-helpers';
 
 class GameProgressInner extends React.Component {
   constructor(props) {
@@ -86,7 +87,9 @@ GameProgress = withTracker(() => {
   const handle = Meteor.subscribe('game.progress');
   const ready = handle.ready();
   const user = Meteor.user();
-  const teams = sortBy(Teams.find({}).fetch(), 'finalScore');
+  const teams = sortBy(Teams.find({}).fetch(), [(team)=>{
+    return getFinalScore(team);
+  }]);
   const puzzles = Puzzles.find({}).fetch();
 
   return {

--- a/lib/collections/admin-methods.js
+++ b/lib/collections/admin-methods.js
@@ -167,7 +167,6 @@ if (Meteor.isServer) {
         $set: {
           puzzles: puzzleCopies,
           currentPuzzle: null,
-          finalScore: 0,
         }
       }, {
         multi: true,

--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -25,7 +25,6 @@ Meteor.startup(function () {
 function teamPuzzleCopy(puzzle) {
   const copy = cloneDeep(omit(puzzle, ['_id']));
   copy.answer = null;
-  // copy.hintsTaken = 0;
   copy.puzzleId = puzzle._id;
   copy.hints.forEach((hint, i) => {
     hint.taken = false;
@@ -377,9 +376,6 @@ Meteor.methods({
       $set: {
         [`puzzles.${puzzleIndex}.hints.${hintIndex}.taken`]: true,
       },
-      // $inc: {
-      //   [`puzzles.${puzzleIndex}.hintsTaken`]: 1,
-      // },
     });
   },
 

--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -26,6 +26,9 @@ function teamPuzzleCopy(puzzle) {
   const copy = cloneDeep(omit(puzzle, ['_id']));
   copy.answer = null;
   copy.puzzleId = puzzle._id;
+  // TODO: change to:
+  // copy.hints.map(()=>({taken: false, takenAt: null}))
+  // to only save 'taken' (t/f) and when hint was taken, if applicable
   copy.hints.forEach((hint, i) => {
     hint.taken = false;
   });
@@ -343,9 +346,9 @@ Meteor.methods({
           [`puzzles.${i}.answer`]: cleanAnswer,
           [`puzzles.${i}.timedOut`]: false,
         },
-        $inc: {
-          finalScore: score,
-        },
+        // $inc: {
+        //   finalScore: score,
+        // },
       });
       return { message: 'Correct!' };
     } else {

--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -11,7 +11,7 @@ import { times,
 } from 'lodash';
 
 import { requireUser, requireVolunteer, NonEmptyString, requirePattern, notAfterCheckIn } from '../imports/method-helpers.js';
-import { scorePuzzle } from '../imports/puzzle-helpers';
+import { getPuzzleScore } from '../imports/puzzle-helpers';
 
 Teams = new Mongo.Collection('teams');
 
@@ -25,7 +25,7 @@ Meteor.startup(function () {
 function teamPuzzleCopy(puzzle) {
   const copy = cloneDeep(omit(puzzle, ['_id']));
   copy.answer = null;
-  copy.hintsTaken = 0;
+  // copy.hintsTaken = 0;
   copy.puzzleId = puzzle._id;
   copy.hints.forEach((hint, i) => {
     hint.taken = false;
@@ -334,7 +334,7 @@ Meteor.methods({
     if (cleanAnswer === masterPuzzle.answer.trim().toLowerCase()) {
       // Yes - Score Puzzle.
       const endTime = new Date();
-      const score = scorePuzzle(team.puzzles[i].start, endTime, team.puzzles[i].hintsTaken, masterPuzzle.bonusTime, masterPuzzle.allowedTime, masterPuzzle.timeoutScore);
+      const score = getPuzzleScore(team.puzzles[i], masterPuzzle);
 
       Teams.update(user.teamId, {
         $set: {
@@ -377,9 +377,9 @@ Meteor.methods({
       $set: {
         [`puzzles.${puzzleIndex}.hints.${hintIndex}.taken`]: true,
       },
-      $inc: {
-        [`puzzles.${puzzleIndex}.hintsTaken`]: 1,
-      },
+      // $inc: {
+      //   [`puzzles.${puzzleIndex}.hintsTaken`]: 1,
+      // },
     });
   },
 

--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -309,7 +309,6 @@ Meteor.methods({
         startLocation: startLocation,
         puzzles: puzzleCopies,
         currentPuzzle: null,
-        finalScore: 0,
       },
     });
   },
@@ -346,9 +345,6 @@ Meteor.methods({
           [`puzzles.${i}.answer`]: cleanAnswer,
           [`puzzles.${i}.timedOut`]: false,
         },
-        // $inc: {
-        //   finalScore: score,
-        // },
       });
       return { message: 'Correct!' };
     } else {

--- a/lib/imports/puzzle-helpers.js
+++ b/lib/imports/puzzle-helpers.js
@@ -8,8 +8,8 @@ const HINT_PENALTY = {
   3: 30
 };
 
-export function getHintsTaken(puzzle){
-  return puzzle.hints.reduce((accum, currVal) => accum + (currVal.taken ? 1 : 0), 0);
+export function getHintsTaken(hints){
+  return hints.reduce((accum, currVal) => accum + (currVal.taken ? 1 : 0), 0);
 }
 
 export function getPuzzleScore(puzzle, masterPuzzzle) {

--- a/lib/imports/puzzle-helpers.js
+++ b/lib/imports/puzzle-helpers.js
@@ -8,7 +8,17 @@ const HINT_PENALTY = {
   3: 30
 };
 
-export function scorePuzzle(startTime, endTime, hintsTaken, puzzleBonusTime, puzzleAllowedTime, puzzleTimeoutTime) {
+export function getHintsTaken(puzzle){
+  return puzzle.hints.reduce((accum, currVal) => accum + (currVal.taken ? 1 : 0), 0);
+}
+
+export function getPuzzleScore(puzzle, masterPuzzzle) {
+  let {start, end, hints} = puzzle;
+  let {bonusTime, allowedTime, timeoutScore} = masterPuzzzle;
+  return __scorePuzzle(start, end, getHintsTaken(hints), bonusTime, allowedTime, timeoutScore);
+}
+
+export function __scorePuzzle(startTime, endTime, hintsTaken, puzzleBonusTime, puzzleAllowedTime, puzzleTimeoutTime) {
   const s = moment(startTime);
   const e = moment(endTime);
   const solveTime = moment.duration(e - s);

--- a/lib/imports/puzzle-helpers.js
+++ b/lib/imports/puzzle-helpers.js
@@ -8,7 +8,9 @@ const HINT_PENALTY = {
   3: 30
 };
 
-export function getHintsTaken(hints){
+export function getHintsTaken(puzzleOrHints){
+  let hints = puzzleOrHints;
+  if(hints.hints) hints = hints.hints;
   return hints.reduce((accum, currVal) => accum + (currVal.taken ? 1 : 0), 0);
 }
 

--- a/lib/imports/puzzle-helpers.js
+++ b/lib/imports/puzzle-helpers.js
@@ -41,3 +41,8 @@ export function __scorePuzzle(startTime, endTime, hintsTaken, puzzleBonusTime, p
 
   return solveTime.asSeconds();
 }
+
+export function getFinalScore(team){
+  let { puzzles } = team;
+  return puzzles.reduce((accum, puzzle) => accum + (puzzle.score ? puzzle.score : 0), 0);
+}

--- a/server/imports/puzzle-watcher.js
+++ b/server/imports/puzzle-watcher.js
@@ -35,9 +35,6 @@ function timeOutPuzzles() {
           [`puzzles.${i}.answer`]: puzzles[puzzle.puzzleId].answer,
           [`puzzles.${i}.timedOut`]: true,
         },
-        $inc: {
-          finalScore: timeOutScore,
-        },
       });
     }
   });

--- a/server/publications/teams.js
+++ b/server/publications/teams.js
@@ -78,7 +78,7 @@ Meteor.publish('game.progress', function() {
     'puzzles.name': 1,
     'puzzles.start': 1,
     'puzzles.end': 1,
-    'puzzles.hintsTaken': 1,
+    // 'puzzles.hintsTaken': 1,
     'puzzles.score': 1,
   };
 

--- a/server/publications/teams.js
+++ b/server/publications/teams.js
@@ -73,12 +73,10 @@ Meteor.publish('game.progress', function() {
     name: 1,
     members: 1,
     division: 1,
-    // finalScore: 1,
     'puzzles.puzzleId': 1,
     'puzzles.name': 1,
     'puzzles.start': 1,
     'puzzles.end': 1,
-    // 'puzzles.hintsTaken': 1,
     'puzzles.score': 1,
   };
 

--- a/server/publications/teams.js
+++ b/server/publications/teams.js
@@ -73,7 +73,7 @@ Meteor.publish('game.progress', function() {
     name: 1,
     members: 1,
     division: 1,
-    finalScore: 1,
+    // finalScore: 1,
     'puzzles.puzzleId': 1,
     'puzzles.name': 1,
     'puzzles.start': 1,


### PR DESCRIPTION
Due to some `$inc` statements in MongoDB updates, some hints were counted multiple times and some scores were added multiple times to the final score due to race conditions caused by multiple simultaneous requests from one or more users on a team.

Helper functions have been put in place to replace some of the `hintCount` and `finalScore` values that are now deprecated and should no longer be stored directly in the database.