### PR TITLE
Fixes first correct answer not being accepted

### DIFF
--- a/lib/collections/teams.js
+++ b/lib/collections/teams.js
@@ -335,7 +335,7 @@ Meteor.methods({
     if (cleanAnswer === masterPuzzle.answer.trim().toLowerCase()) {
       // Yes - Score Puzzle.
       const endTime = new Date();
-      const score = getPuzzleScore(team.puzzles[i], masterPuzzle);
+      const score = getPuzzleScore(team.puzzles[i], endTime, masterPuzzle);
 
       Teams.update(user.teamId, {
         $set: {

--- a/lib/imports/puzzle-helpers.js
+++ b/lib/imports/puzzle-helpers.js
@@ -14,10 +14,10 @@ export function getHintsTaken(puzzleOrHints){
   return hints.reduce((accum, currVal) => accum + (currVal.taken ? 1 : 0), 0);
 }
 
-export function getPuzzleScore(puzzle, masterPuzzzle) {
-  let {start, end, hints} = puzzle;
+export function getPuzzleScore(puzzle, endTime, masterPuzzzle) {
+  let {start, hints} = puzzle;
   let {bonusTime, allowedTime, timeoutScore} = masterPuzzzle;
-  return __scorePuzzle(start, end, getHintsTaken(hints), bonusTime, allowedTime, timeoutScore);
+  return __scorePuzzle(start, endTime, getHintsTaken(hints), bonusTime, allowedTime, timeoutScore);
 }
 
 export function __scorePuzzle(startTime, endTime, hintsTaken, puzzleBonusTime, puzzleAllowedTime, puzzleTimeoutTime) {


### PR DESCRIPTION
The first correct answer was not being accepted when a user tried to solve a puzzle. This was because the `endTime` value being passed to the score calculation function was undefined, meaning that the final score was `NaN` and thus the puzzle appeared to be unsolved (since `Boolean(NaN) === false`).