### PR TITLE
Additional fixes and updates for non-competitive

### DIFF
--- a/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardDivisionTable.jsx
+++ b/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardDivisionTable.jsx
@@ -19,8 +19,18 @@ class AdminLeaderboardDivisionTable extends Component {
   render() {
     const { division, teams } = this.props;
 
-    const sortedTeams = sortBy(teams, (team) => {
+    const preSortedTeams = sortBy(teams, (team) => {
       return getFinalScore(team) + (team.finished ? 0 : UNFINISHED_OFFSET);
+    });
+    const sortedTeams = sortBy(preSortedTeams, team => {
+      /* Sort by the number of puzzles completed (not include those that they gave up on) */
+      let nComplete = 0;
+      team.puzzles.forEach(puzzle => {
+        const { gaveUp, end } = puzzle;
+        if(end && !gaveUp) nComplete++;
+      });
+      console.log(`${team.name} completed ${nComplete} puzzles`);
+      return -nComplete;
     });
 
     return (
@@ -71,14 +81,15 @@ class AdminLeaderboardDivisionTable extends Component {
   }
 
   _renderPuzzle(puzzle) {
-    const { score, start, end } = puzzle;
+    const { score, start, end, gaveUp } = puzzle;
     let hintsTaken = getHintsTaken(puzzle);
     const started = Boolean(start);
     const finished = Boolean(end);
     const inProgress = started && !finished;
     return (
       <Table.Cell key={puzzle.puzzleId} positive={finished} warning={!finished}>
-    {finished ? <code>{renderScore(puzzle.score).time} (hints {hintsTaken}) ({puzzle.score} sec)</code> : null }
+        { gaveUp ? <Icon name="ban" color="red" /> : null }
+        {finished ? <code>{renderScore(puzzle.score).time} (hints {hintsTaken}) ({puzzle.score} sec)</code> : null }
         {inProgress ? <div><Icon name="spinner" color="blue" loading /> In Progress</div> : null }
         { !started ? <code>--:--:--</code> : null }
       </Table.Cell>

--- a/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardDivisionTable.jsx
+++ b/client/components/admin/AdminLeaderboard/imports/AdminLeaderboardDivisionTable.jsx
@@ -29,7 +29,6 @@ class AdminLeaderboardDivisionTable extends Component {
         const { gaveUp, end } = puzzle;
         if(end && !gaveUp) nComplete++;
       });
-      console.log(`${team.name} completed ${nComplete} puzzles`);
       return -nComplete;
     });
 

--- a/client/components/imports/PuzzleProgress.jsx
+++ b/client/components/imports/PuzzleProgress.jsx
@@ -19,7 +19,7 @@ export function renderDuration(duration) {
   const hours = pad(duration.hours().toString(), 2);
   const minutes = pad(duration.minutes().toString(), 2);
   const seconds = pad(duration.seconds().toString(), 2);
-  const negative = (hours < 0) || (minutes < 0) || (seconds < 0) ? "- " : "";
+  const negative = (hours < 0) || (minutes < 0) || (seconds < 0) ? "-" : "";
   return `${negative}${pad(Math.abs(hours))}:${pad(Math.abs(minutes))}:${pad(Math.abs(seconds))}`;
 }
 

--- a/client/components/team/TeamEditor.jsx
+++ b/client/components/team/TeamEditor.jsx
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link, browserHistory } from 'react-router';
-import { Form, Message, Input, Popup, Icon, Checkbox } from 'semantic-ui-react';
+import { Form, Message, Input, Popup, Icon, Checkbox, Confirm, Segment } from 'semantic-ui-react';
 import { DIVISION_TYPES } from "./imports/team-helpers"
 
 TeamEditor = class TeamEditor extends Component {
@@ -10,6 +10,7 @@ TeamEditor = class TeamEditor extends Component {
   constructor(props) {
     super(props);
     this.state = this._getStateFromProps(props);
+    this.state.showConfirm = false;
 
     this.divisions = [...DIVISION_TYPES];
 
@@ -41,6 +42,8 @@ TeamEditor = class TeamEditor extends Component {
   render() {
     return (
       <Form widths='equal' onSubmit={(e) => this._saveTeam(e)}>
+
+        {this._ncConfirmation()}
 
         { (this.state.checkedIn) ? <Message positive header="Check in Confirmed" content="Your team is checked in an cannot be updated anymore"/> : null}
 
@@ -111,9 +114,28 @@ TeamEditor = class TeamEditor extends Component {
   _handleDataChange(e, data) {
     const { name, value, checked } = data;
     if(value === "noncompetitive"){
-      if(!confirm("Are you sure? Non-competitive teams do not have a time limit and are not eligible for prizes!")) return;
+      this.setState({showConfirm: true});
+    } else {
+      this.setState({ [name]: (value || checked) });
     }
-    this.setState({ [name]: (value || checked) });
+  }
+
+  _ncConfirmation(){
+    let { showConfirm } = this.state;
+    return (
+      <Confirm
+        open={showConfirm}
+        header="Are you sure?"
+        content={<Segment basic style={{fontSize: '16px'}}>
+          <p>Non-competitive teams do not have a time limit and are not eligible for prizes but for bragging rights, teams that solve at least one puzzle are recognized online for the number of puzzles completed!</p>
+        </Segment>}
+        confirmButton={`Yes, Non-Competitive`}
+        cancelButton="Nevermind"
+        onConfirm={() => this.setState({showConfirm: false, division: "noncompetitive" })}
+        onCancel={() => this.setState({showConfirm: false})}
+        size="large"
+      />
+    );
   }
 
   _saveTeam(e) {

--- a/client/components/team/imports/team-helpers.js
+++ b/client/components/team/imports/team-helpers.js
@@ -5,7 +5,7 @@ export const DIVISION_TYPES = [
   {
     text: 'WWU Student',
     value: 'wwu-student',
-    wristBandColor: "Orange",
+    wristBandColor: "Green",
     description: "All team members must be currently enrolled at WWU (undergrad or grad)."
   },
   {
@@ -17,21 +17,21 @@ export const DIVISION_TYPES = [
   {
     text: 'High School',
     value: 'highschool',
-    wristBandColor: "Green",
+    wristBandColor: "Purple",
     description: "All team members must be currently enrolled in high school. Exception: One adult chaperone per team may register as a team member."
   },
   {
     text: 'Open',
     value: 'open',
-    wristBandColor: "Yellow",
+    wristBandColor: "Orange",
     description: "General public, mixed student/non-student, family (children under age 14 must be accompanied by a parent/guardian)."
   },
-  // {
-  //   text: "Non-Competitive",
-  //   value: "noncompetitive",
-  //   wristBandColor: "(unknown)",
-  //   description: "All teams who enjoy puzzling without time pressure."
-  // },
+  {
+    text: "Non-Competitive",
+    value: "noncompetitive",
+    wristBandColor: "Yellow",
+    description: "All teams who enjoy puzzling without time pressure."
+  },
 ];
 
 export const WRIST_BAND_COLOR = function(){


### PR DESCRIPTION
* Updates leaderboard - sort by # of puzzles finished, then by score
* Use semantic-ui modals for confirmation pop-ups instead of browser's built-in `confirm()`
* Updates wrist band colors for check-in table